### PR TITLE
Confluent Platform v4.0.1

### DIFF
--- a/Formula/confluent-oss.rb
+++ b/Formula/confluent-oss.rb
@@ -1,9 +1,9 @@
 class ConfluentOss < Formula
   desc "Developer-optimized distribution of Apache Kafka"
   homepage "https://www.confluent.io/product/confluent-open-source/"
-  url "https://packages.confluent.io/archive/4.0/confluent-oss-4.0.0-2.11.tar.gz"
-  version "4.0.0"
-  sha256 "5cfa68b4368f28bd9231786bb710431394dc14a2b37eecf360e820271ee84f43"
+  url "https://packages.confluent.io/archive/4.0/confluent-oss-4.0.1-2.11.tar.gz"
+  version "4.0.1"
+  sha256 "335d1440a7cd18341a62c5e2584e8e0f7d52c3070940a60bde3166ad8bb1100e"
 
   depends_on :java => "1.8"
   conflicts_with "kafka", :because => "kafka also ships with identically named Kafka related executables"


### PR DESCRIPTION
💁 These changes bump the Confluent Platform version to 4.0.1.