### PR TITLE
Remove systemd service definitions

### DIFF
--- a/Formula/confluent-oss.rb
+++ b/Formula/confluent-oss.rb
@@ -12,7 +12,6 @@ class ConfluentOss < Formula
     prefix.install "bin"
     rm_rf "#{bin}/windows"
     prefix.install "etc"
-    prefix.install "lib"
     prefix.install "share"
     prefix.install "src"
   end


### PR DESCRIPTION
💁 Until macOS starts using `systemd`, these files are not relevant. Reverts part of #6.
```
confluent-4.1.1/lib/
confluent-4.1.1/lib/systemd/
confluent-4.1.1/lib/systemd/system/
confluent-4.1.1/lib/systemd/system/confluent-zookeeper.service
confluent-4.1.1/lib/systemd/system/confluent-kafka-connect.service
confluent-4.1.1/lib/systemd/system/confluent-kafka-rest.service
confluent-4.1.1/lib/systemd/system/confluent-kafka.service
confluent-4.1.1/lib/systemd/system/confluent-schema-registry.service
confluent-4.1.1/lib/systemd/system/confluent-ksql.service
```